### PR TITLE
feat: support cross package imports for field types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The following protobuf features are supported:
   - String `min_len`, `max_len`, `pattern`, various formats like `uri-ref`
   - Arrays `min_items`, `max_items`, `unique`
   - Enum `not_in`
+- Complex nested packages
+- Cross-package imports as field types
 
 ## Annotations
 
@@ -133,9 +135,13 @@ High level pseudo-code:
         - Figure out Huma naming & type
         - Convert validation to Huma's JSON-Schema tags
       - Generate `FromProto` and `ToProto` converter methods
-  - Write out `$BASENAME.huma.go`
+  - Write out `$DIRNAMEhuma/$BASENAME.huma.go`
 
 ## Implementation Details
+
+### Two-Pass Processing
+
+Two passes are done on each file. First, we go through all files and build up a registry of message and enum types for lookup later. During that first pass we also process enums so they can be easily used later. Then we do a second pass to process all the messages, convert the field types, handle all the renaming, etc. This is necessary because a message field in one package may use a type (message or enum) defined in another package we may not have processed yet.
 
 ### Comments
 

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func buildEnum(file *descriptor.FileDescriptorProto, prefix string, path []int32
 	prefix = stripPkg(prefix)
 
 	// If nested, prefix will be set with the outer name. We append to it below.
-	p := casing.Join(strings.Split(prefix, " "), "_", casing.Identity)
+	p := casing.Join(strings.Split(prefix, "."), "_", casing.Identity)
 	if p != "" {
 		p += "_"
 	}

--- a/model.go
+++ b/model.go
@@ -7,6 +7,9 @@ type EnumValue struct {
 	// Name is the Huma name for the enum value.
 	Name string
 
+	// Comment for the enum value, if any.
+	Comment string
+
 	// Label is the protobuf label for the enum value.
 	Label string
 

--- a/proto/package1/example.proto
+++ b/proto/package1/example.proto
@@ -1,12 +1,14 @@
 syntax = "proto3";
 
-package example;
+package package1;
 
 import "google/protobuf/timestamp.proto";
 import "annotation/huma.proto";
 import "annotation/validate.proto";
 
-option go_package = "github.com/istreamlabs/protoc-gen-huma/example;example";
+import "package2/example2.proto";
+
+option go_package = "github.com/istreamlabs/protoc-gen-huma/example/package1;package1";
 
 enum Global {
     NONE = 0;
@@ -37,13 +39,16 @@ message Message {
     }
     google.protobuf.Timestamp ts = 18 [(huma.public) = true];
     bool mp2t = 19 [(huma.public) = true, (huma.name) = "MP2T", (huma.json) = "mp2t"];
+    package2.Message cross_package = 20 [(huma.public) = true];
+    package2.Fruits fruit = 21 [(huma.public) = true];
 }
 
 message Sub {
+    // Nested enum definition comment.
     enum Nested {
         NONE = 0 [(huma.exclude) = true];
-        FOO = 1;
-        BAR = 2;
+        FOO = 1; // Foo description
+        BAR = 2; // Bar description
     }
 
     Nested CamelCaseEnum = 1 [(huma.public) = true];

--- a/proto/package2/example2.proto
+++ b/proto/package2/example2.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package package2;
+
+import "annotation/huma.proto";
+
+option go_package = "github.com/istreamlabs/protoc-gen-huma/example/package2;package2";
+
+enum Fruits {
+    NONE = 0 [(huma.exclude) = true];
+    APPLE = 1;
+    PEAR = 2;
+    ORANGE = 3;
+}
+
+message Message {
+    string name = 1 [(huma.public) = true];
+}

--- a/template.go
+++ b/template.go
@@ -29,6 +29,7 @@ import (
 
 	const (
 		{% for value in enum.Values -%}
+			{% if value.Comment %}// {{ value.Comment }}{% endif %}
 			{{ enum.Name }}{{ value.Name }} {{ enum.Name }} = "{{ value.Label }}"
 		{% endfor %}
 	)
@@ -113,7 +114,7 @@ func (m *{{ msg.Name }}) Resolve(ctx huma.Context, r *http.Request) {
 			tmp := {{ field.GoType }}{}
 			for _, i := range {{ proto }}.{{ field.ProtoGoName }} {
 				{% if field.Enum -%}
-					enumValue := {{ field.Enum.Name }}NamesMap[i]
+					enumValue := {{ field.GoType|slice:"2:" }}NamesMap[i]
 					if enumValue == "" {
 						continue
 					}
@@ -129,7 +130,7 @@ func (m *{{ msg.Name }}) Resolve(ctx huma.Context, r *http.Request) {
 		}
 	{% else -%}
 		{% if field.Enum -%}
-			if v, ok := {{ field.Enum.Name }}NamesMap[{{ proto }}.{{ field.ProtoGoName }}]; ok {
+			if v, ok := {{ field.GoType }}NamesMap[{{ proto }}.{{ field.ProtoGoName }}]; ok {
 				m.{{ field.Name }} = v
 			}
 		{% else -%}
@@ -184,7 +185,7 @@ func (m *{{ msg.Name }}) FromProto(proto *{{ file.PackageName}}.{{ msg.ProtoGoNa
 			tmp := {{ field.ProtoGoType }}{}
 			for _, i := range m.{{ field.Name }} {
 				{% if field.Enum -%}
-					if v, ok := {{ field.Enum.Name }}ValuesMap[i]; ok {
+					if v, ok := {{ field.GoType|slice:"2:" }}ValuesMap[i]; ok {
 						tmp = append(tmp, v)
 					}
 				{% else -%}
@@ -199,7 +200,7 @@ func (m *{{ msg.Name }}) FromProto(proto *{{ file.PackageName}}.{{ msg.ProtoGoNa
 	{% else -%}
 		{% if field.Enum -%}
 			if m.{{ field.Name }} != "" {
-				{{ proto }}.{{ field.ProtoGoName }} = {{ field.Enum.Name }}ValuesMap[m.{{ field.Name }}]
+				{{ proto }}.{{ field.ProtoGoName }} = {{ field.GoType }}ValuesMap[m.{{ field.Name }}]
 			}
 		{% else -%}
 			if m.{{ field.Name }} != nil {


### PR DESCRIPTION
We ran into a bug when trying to have a proto file reference a type defined in another proto file. This change:

- Better support for nested packages
- Makes referencing types (messages & enums) defined in other files work
- Support for reading trailing comments
- Support for enum value comments
- Some code refactoring

Tests are updated and continue to work. They test almost all of the functionality in `main.go` and the template.