### PR TITLE
fix: one-of should only be set if value was provided

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     name: Build & Test
     steps:
       - uses: actions/checkout@v2

--- a/proto/package1/example.proto
+++ b/proto/package1/example.proto
@@ -36,6 +36,7 @@ message Message {
     oneof only_one {
         string tag = 16 [(huma.public) = true];
         Another another = 17 [(huma.public) = true];
+        int32 count = 22 [(huma.public) = true];
     }
     google.protobuf.Timestamp ts = 18 [(huma.public) = true];
     bool mp2t = 19 [(huma.public) = true, (huma.name) = "MP2T", (huma.json) = "mp2t"];


### PR DESCRIPTION
This change fixes a bug where the last entry in a `one-of` would win, even when not being explicitly set. Rather than always setting `proto.{{ field.OneOf }} = oneof` in the template it is now only set when a field is present. This adds a set of `one-of` round-trip tests which fail with the old behavior and are working with the changes in this PR. TL;DR:

```go
// === Before ===
{
  oneof := ...
  if m.Field1 != nil {
    oneof.Field1 = m.Field1
  }
  proto.OneOfName = oneof
}

{
  oneof := ...
  if m.Field2 != nil {
    oneof.Field2 = m.Field2
  }
  proto.OneOfName = oneof //   ← this will *always* overwrite! 😢 
}

// === After ===
{
  oneof := ...
  if m.Field1 != nil {
    oneof.Field1 = m.Field1
    proto.OneOfName = oneof
  }
}

{
  oneof := ...
  if m.Field2 != nil {
    oneof.Field2 = m.Field2
    proto.OneOfName = oneof //   ← this is now protected by the `if`
  }
}
```

Also fixes a minor error message issue where the message name wasn't being interpolated.